### PR TITLE
New option `readManifest` allows custom translation of pkgPath to pkg json

### DIFF
--- a/example/config.js
+++ b/example/config.js
@@ -1,7 +1,3 @@
-args
-[ 'node',
-  '/Users/karolis/Documents/workspace/requirejs-configurator/bin/requirejs-configurator',
-  '--npm' ]
 require.config({
   "map": {
     "*": {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -15,13 +15,16 @@ function generate(options, cb) {
   var dependencies = options.dependencies;
   // a function that can resolve paths of packages
   var resolve = options.resolve;
+  // a function that reads the pkg manifest
+  var readManifest = options.readManifest || defaultReadManifest;
+
   // support node style API
   if (resolve.length === 4) {
     resolve = nodefn.lift(resolve);
   }
 
   // collect the manifests of the entire dependency tree
-  var manifests = collectManifests(dependencies, resolve);
+  var manifests = collectManifests(dependencies, resolve, readManifest);
 
   var config = when.try(createConfig, manifests);
 
@@ -38,15 +41,15 @@ function createConfig(manifests) {
   };
 }
 
-function collectManifests(dependencies, resolve) {
+function collectManifests(dependencies, resolve, readManifest) {
   var moduleManifests = {};
-  var add = addPackage.bind(null, moduleManifests, null, resolve);
+  var add = addPackage.bind(null, moduleManifests, null, resolve, readManifest);
   return when.map(dependencies, add).then(function () {
     return moduleManifests;
   });
 }
 
-function addPackage(moduleManifests, basedir, resolve, pkg) {
+function addPackage(moduleManifests, basedir, resolve, readManifest, pkg) {
   // check if already processed or processing
   if (moduleManifests[pkg]) {
     return;
@@ -54,22 +57,27 @@ function addPackage(moduleManifests, basedir, resolve, pkg) {
     moduleManifests[pkg] = true;
   }
 
-  return readManifest(pkg, basedir, resolve).then(function (manifest) {
+  return getManifest(resolve, readManifest, pkg, basedir).then(function (manifest) {
     moduleManifests[pkg] = manifest;
     return when.all(mapObj(function (version, pkg) {
-      return addPackage(moduleManifests, manifest._location, resolve, uid.create(pkg, version));
+      return addPackage(moduleManifests, manifest._location, resolve, readManifest, uid.create(pkg, version));
     }, allDependencies(manifest)));
   });
 }
 
-function readManifest(pkgUid, basedir, resolve) {
+function getManifest(resolve, readManifest, pkgUid, basedir) {
   var pkg = uid.parse(pkgUid);
-  return resolve(pkg.name, pkg.version, basedir).then(function (modulePath) {
-    return readFile(path.join(modulePath, "package.json")).then(function (moduleConfig) {
-      var manifest = JSON.parse(moduleConfig.toString());
-      manifest._location = modulePath;
-      return manifest;
-    });
+  return resolve(pkg.name, pkg.version, basedir).then(function (pkgPath) {
+    return readManifest(pkgPath).then(function (manifest) {
+      manifest._location = pkgPath
+      return manifest
+    })
+  })
+}
+
+function defaultReadManifest(pkgPath) {
+  return readFile(path.join(pkgPath, "package.json")).then(function (moduleManifest) {
+    return JSON.parse(moduleManifest.toString());
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requirejs-configurator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A generic require.js configuration generator for npm style projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This enables a caching use case where readManifest function could
cache the manifests.

Couldn't think of a simpler way to achieve this. @alexjesp @mattliving