### PR TITLE
Fix #16

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -88,7 +88,7 @@ function makeResolve(root) {
     return when.promise(function (resolve, reject) {
       resolveModule(name + "/package.json", {basedir: basedir || root}, function (err, location) {
         if (err) return reject(err);
-        resolve(path.dirname(location));
+        resolve(location ? path.dirname(location) : undefined);
       });
     });
   };


### PR DESCRIPTION
Fix incompatability with Node.js v6. Do not call `path.dirname` is the module path is undefined.
