### PR TITLE
Exclude peerDependencies

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -109,7 +109,7 @@ function makeMap (manifests) {
 }
 
 function allDependencies (manifest) {
-  return R.mixin(manifest.peerDependencies, manifest.dependencies)
+  return R.mixin({}, manifest.dependencies)
 }
 
 function makePackages (manifests) {


### PR DESCRIPTION
Exclude peerDependencies as they are not meant to be required (And are not installed starting from NPM >= 3). See https://github.com/QubitProducts/requirejs-configurator/pull/20.